### PR TITLE
push tags and commits

### DIFF
--- a/.github/workflows/push-to-gitlab.yml
+++ b/.github/workflows/push-to-gitlab.yml
@@ -20,4 +20,5 @@ jobs:
           git config --global user.name $GITHUB_ACTOR
           git remote add github https://github.com/yigbt/deepFPlearn.git
           git pull github master
+          git push --tags https://Normo:$ACCESS_TOKEN@gitlab.hzdr.de/Normo/deepFPlearn.git/
           git push https://Normo:$ACCESS_TOKEN@gitlab.hzdr.de/Normo/deepFPlearn.git/


### PR DESCRIPTION
you can't push releases via git, because its specific for GitHub/GitLab, but you can push the tags and then I can add a CI/CD pipeline to create the release also in GitLab based on the tag.